### PR TITLE
Update to runtime 1200

### DIFF
--- a/scripts/xcm-asset-registrator.ts
+++ b/scripts/xcm-asset-registrator.ts
@@ -51,13 +51,12 @@ async function main () {
         sourceLocation,
         assetMetadata,
         args["existential-deposit"],
-        // This needs to be uncommented for runtime 1200
-    //    args["sufficient"]
+        args["sufficient"]
     ))
 
     registerTxs.push(
         api.tx.assetManager.setAssetUnitsPerSecond(
-            assetId,
+            sourceLocation,
             args["units-per-second"]
     ));
 


### PR DESCRIPTION
Update to runtime 1200, which includes:
- choosing whether the asset will be sufficient
- units per second now referenced as multilocation