### PR TITLE
Use Geneis Hash for Fees instead of Decimals

### DIFF
--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -1,176 +1,167 @@
 // Import
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { u8aToHex, hexToU8a } from '@polkadot/util';
-import { BN } from '@polkadot/util';
+import {u8aToHex, hexToU8a} from '@polkadot/util';
+import { BN } from "@polkadot/util";
 
-import { blake2AsHex, xxhashAsU8a, blake2AsU8a } from '@polkadot/util-crypto';
+import {blake2AsHex, xxhashAsU8a, blake2AsU8a} from '@polkadot/util-crypto';
 import yargs from 'yargs';
-import { Keyring } from '@polkadot/api';
+import { Keyring } from "@polkadot/api";
 import { ParaId } from '@polkadot/types/interfaces';
 
 const args = yargs.options({
-  'parachain-ws-provider': { type: 'string', demandOption: true, alias: 'wp' },
-  'relay-ws-provider': { type: 'string', demandOption: true, alias: 'wr' },
-  'hrmp-action': {
-    choices: ['accept', 'cancel', 'close', 'open'],
-    demandOption: true,
-    alias: 'hrmp',
-  },
-  'target-para-id': { type: 'number', demandOption: true, alias: 'p' },
-  'max-capacity': { type: 'number', demandOption: false, alias: 'mc' },
-  'max-message-size': { type: 'number', demandOption: false, alias: 'mms' },
-  'account-priv-key': { type: 'string', demandOption: false, alias: 'account' },
-  'send-preimage-hash': { type: 'boolean', demandOption: false, alias: 'h' },
-  'send-proposal-as': {
-    choices: ['democracy', 'council-external'],
-    demandOption: false,
-    alias: 's',
-  },
-  'collective-threshold': { type: 'number', demandOption: false, alias: 'c' },
-  'at-block': { type: 'number', demandOption: false },
-}).argv;
-
+    'parachain-ws-provider': {type: 'string', demandOption: true, alias: 'wp'},
+    'relay-ws-provider': {type: 'string', demandOption: true, alias: 'wr'},
+    'hrmp-action': {choices: ['accept', 'cancel', 'close', 'open'], demandOption: true, alias: 'hrmp'},
+    'target-para-id': {type: 'number', demandOption: true, alias: 'p'},
+    'max-capacity': {type: 'number', demandOption: false, alias: 'mc'},
+    'max-message-size': {type: 'number', demandOption: false, alias: 'mms'},
+    'account-priv-key': {type: 'string', demandOption: false, alias: 'account'},
+    'send-preimage-hash': {type: 'boolean', demandOption: false, alias: 'h'},
+    'send-proposal-as': {choices: ['democracy', 'council-external'], demandOption: false, alias: 's'},
+    'collective-threshold': {type: 'number', demandOption: false, alias: 'c'},
+    'at-block': {type: 'number', demandOption: false},
+  }).argv;
+ 
 // Construct
 const wsProvider = new WsProvider(args['parachain-ws-provider']);
 const relayProvider = new WsProvider(args['relay-ws-provider']);
 
-async function main() {
-  const api = await ApiPromise.create({ provider: wsProvider });
-  const relayApi = await ApiPromise.create({ provider: relayProvider });
+async function main () {
+    const api = await ApiPromise.create({ provider: wsProvider });
+    const relayApi = await ApiPromise.create({ provider: relayProvider });
 
-  const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
+    const proposalAmount = await api.consts.democracy.minimumDeposit as any;
 
-  const collectiveThreshold = args['collective-threshold'] ? args['collective-threshold'] : 1;
+    const collectiveThreshold = (args['collective-threshold']) ? args['collective-threshold'] :1;
 
-  const keyring = new Keyring({ type: 'ethereum' });
-  const selfParaId: ParaId = (await api.query.parachainInfo.parachainId()) as any;
+    const keyring = new Keyring({ type: "ethereum" });
+    const selfParaId: ParaId = await api.query.parachainInfo.parachainId() as any;
 
-  let relayCall;
-  if (args['hrmp-action'] == 'accept') {
-    relayCall = relayApi.tx.hrmp.hrmpAcceptOpenChannel(args['target-para-id']);
-  } else if (args['hrmp-action'] == 'open') {
-    relayCall = relayApi.tx.hrmp.hrmpInitOpenChannel(
-      args['target-para-id'],
-      args['max-capacity'],
-      args['max-message-size']
-    );
-  } else if (args['hrmp-action'] == 'cancel') {
-    relayCall = relayApi.tx.hrmp.hrmpCancelOpenRequest({
-      sender: selfParaId,
-      recipient: args['target-para-id'],
-    });
-  } else {
-    relayCall = relayApi.tx.hrmp.hrmpCloseChannel({
-      sender: selfParaId,
-      recipient: args['target-para-id'],
-    });
-  }
-
-  let relayCall2 = relayCall?.method.toHex() || '';
-  // Sovereign account is b"para" + encode(parahain ID) + trailling zeros
-  let para_address = u8aToHex(
-    new Uint8Array([...new TextEncoder().encode('para'), ...selfParaId.toU8a()])
-  ).padEnd(66, '0');
-
-  // get the chain information
-  let feeAmount;
-  const genesisHash = (await relayApi.genesisHash) as any;
-  switch (genesisHash.toString()) {
-    case '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443':
-      //Moonbase Alpha Relay - 1 UNIT
-      feeAmount = new BN(1000000000000);
-      break;
-    case '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe':
-      // Kusama - 1 KSM
-      feeAmount = new BN(1000000000000);
-    case '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3':
-      // Polkadot - 10 DOT
-      feeAmount = new BN(100000000000);
-    default:
-      // We dont know what relay chain is this
-      throw new Error();
-  }
-
-  const batchCall = api.tx.polkadotXcm.send(
-    { V1: { parents: new BN(1), interior: 'Here' } },
-    {
-      V2: [
-        {
-          WithdrawAsset: [
+    let relayCall;
+    if (args['hrmp-action'] == "accept") {
+        relayCall = relayApi.tx.hrmp.hrmpAcceptOpenChannel(
+            args["target-para-id"]
+        )
+    }
+    else if (args['hrmp-action'] == "open") {
+        relayCall = relayApi.tx.hrmp.hrmpInitOpenChannel(
+            args["target-para-id"],
+            args["max-capacity"],
+            args["max-message-size"]
+        )
+    }
+    else if (args['hrmp-action'] == "cancel") {
+        relayCall = relayApi.tx.hrmp.hrmpCancelOpenRequest(
             {
-              id: { Concrete: { parents: new BN(0), interior: 'Here' } },
-              fun: { Fungible: feeAmount },
-            },
-          ],
-        },
-        {
-          BuyExecution: {
-            fees: {
-              id: { Concrete: { parents: new BN(0), interior: 'Here' } },
-              fun: { Fungible: feeAmount },
-            },
-            weightLimit: { Limited: new BN(5000000000) },
-          },
-        },
-        {
-          Transact: {
-            originType: 'Native',
-            requireWeightAtMost: new BN(1000000000),
-            call: {
-              encoded: relayCall2,
-            },
-          },
-        },
-        {
-          DepositAsset: {
-            assets: { Wild: 'All' },
-            max_assets: 1,
-            beneficiary: {
-              parents: new BN(0),
-              interior: { X1: { AccountId32: { network: 'Any', id: para_address } } },
-            },
-          },
-        },
-      ],
+                sender: selfParaId,
+                recipient:  args["target-para-id"],
+            }
+        )
     }
-  );
-
-  console.log('Encoded proposal for PolkdotXcmSend is %s', batchCall.method.toHex() || '');
-
-  const toPropose = args['at-block']
-    ? api.tx.scheduler.schedule(args['at-block'], null, 0, { Value: batchCall })
-    : batchCall;
-
-  const account = await keyring.addFromUri(args['account-priv-key'], null, 'ethereum');
-  const { nonce: rawNonce, data: balance } = (await api.query.system.account(
-    account.address
-  )) as any;
-  let nonce = BigInt(rawNonce.toString());
-
-  // We just prepare the proposals
-  let encodedProposal = toPropose?.method.toHex() || '';
-  let encodedHash = blake2AsHex(encodedProposal);
-  console.log('Encoded proposal for batch utility after schedule is %s', encodedProposal);
-  console.log('Encoded proposal hash for batch utility after schedule is %s', encodedHash);
-  console.log('Encoded length %d', encodedProposal.length);
-
-  if (args['send-preimage-hash']) {
-    await api.tx.democracy.notePreimage(encodedProposal).signAndSend(account, { nonce: nonce++ });
-
-    if (args['send-proposal-as'] == 'democracy') {
-      await api.tx.democracy
-        .propose(encodedHash, proposalAmount)
-        .signAndSend(account, { nonce: nonce++ });
-    } else if (args['send-proposal-as'] == 'council-external') {
-      let external = api.tx.democracy.externalProposeMajority(encodedHash);
-
-      await api.tx.councilCollective
-        .propose(collectiveThreshold, external, external.length)
-        .signAndSend(account, { nonce: nonce++ });
+    else {
+        relayCall = relayApi.tx.hrmp.hrmpCloseChannel(
+            {
+                sender: selfParaId,
+                recipient:  args["target-para-id"],
+            }
+        )
     }
-  }
+
+    let relayCall2 = relayCall?.method.toHex() || "";
+    // Sovereign account is b"para" + encode(parahain ID) + trailling zeros
+    let para_address = u8aToHex((new Uint8Array([ ...new TextEncoder().encode("para"), ...selfParaId.toU8a()]))).padEnd(66, "0");
+
+    // get the chain information
+    let feeAmount;
+    const genesisHash = (await relayApi.genesisHash) as any;
+    switch (genesisHash.toString()) {
+        case '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443':
+            //Moonbase Alpha Relay - 1 UNIT
+            feeAmount = new BN(1000000000000);
+            break;
+        case '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe':
+            // Kusama - 1 KSM
+            feeAmount = new BN(1000000000000);
+            break;
+        case '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3':
+            // Polkadot - 10 DOT
+            feeAmount = new BN(100000000000);
+            break;
+        default:
+            // We dont know what relay chain is this
+            throw new Error();
+    }
+
+    const batchCall =  api.tx.polkadotXcm.send(
+        { V1: { parents: new BN(1), interior: "Here"} },
+        { V2: [
+            { WithdrawAsset: [
+                { id: { Concrete: { parents: new BN(0), interior: "Here"} },
+                  fun: { Fungible: feeAmount }
+                }
+            ]
+            },
+            { BuyExecution:  {
+                fees:
+                    { id: { Concrete: { parents: new BN(0), interior: "Here"} },
+                    fun: { Fungible: feeAmount }
+                    },
+                weightLimit: {Limited: new BN(5000000000)}
+                }
+            },
+            { Transact:  {
+                originType: "Native",
+                requireWeightAtMost: new BN(1000000000),
+                call: {
+                    encoded: relayCall2
+                   }
+                }
+            },
+            { DepositAsset:  {
+                assets: {Wild: "All"},
+                max_assets: 1,
+                beneficiary: { parents: new BN(0), interior: { X1: { AccountId32: { network: "Any", id: para_address } } }}
+                }
+            },
+            ]
+        });
+
+    console.log("Encoded proposal for PolkdotXcmSend is %s", batchCall.method.toHex() || "");
+
+    const toPropose = args['at-block'] ? 
+        api.tx.scheduler.schedule(args["at-block"], null, 0, {Value: batchCall}) :
+        batchCall;
+
+    const account =  await keyring.addFromUri(args['account-priv-key'], null, "ethereum");
+    const { nonce: rawNonce, data: balance } = await api.query.system.account(account.address) as any;
+    let nonce = BigInt(rawNonce.toString());
+
+    // We just prepare the proposals
+    let encodedProposal = toPropose?.method.toHex() || "";
+    let encodedHash = blake2AsHex(encodedProposal);
+    console.log("Encoded proposal for batch utility after schedule is %s", encodedProposal);
+    console.log("Encoded proposal hash for batch utility after schedule is %s", encodedHash);
+    console.log("Encoded length %d", encodedProposal.length);
+
+    if (args["send-preimage-hash"]) {
+        await api.tx.democracy
+        .notePreimage(encodedProposal)
+        .signAndSend(account, { nonce: nonce++ });
+
+        if (args["send-proposal-as"] == 'democracy') {
+            await api.tx.democracy
+            .propose(encodedHash, proposalAmount)
+            .signAndSend(account, { nonce: nonce++ });
+        }
+        else if (args["send-proposal-as"] == 'council-external') {
+            let external =  api.tx.democracy.externalProposeMajority(encodedHash)
+            
+            await api.tx.councilCollective
+            .propose(collectiveThreshold, external, external.length)
+            .signAndSend(account, { nonce: nonce++ });
+        }
+    }
 }
 
-main()
-  .catch(console.error)
-  .finally(() => process.exit());
+
+main().catch(console.error).finally(() => process.exit());

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -74,7 +74,7 @@ async function main () {
     // get the chain information
     let feeAmount;
     const genesisHash = (await relayApi.genesisHash) as any;
-    switch (genesisHash.toString()) {
+    switch (genesisHash.toString().toLowerCase()) {
         case '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443':
             //Moonbase Alpha Relay - 1 UNIT
             feeAmount = new BN(1000000000000);

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -75,7 +75,7 @@ async function main () {
     let feeAmount;
     // Get Decimals
     const relayChainInfo = (await relayApi.registry.getChainProperties()) as any;
-    switch (relayChainInfo['tokenDecimals'].toHuman()[0]) {
+    switch (relayChainInfo['tokenDecimals'].toHuman()?.[0]) {
         case '12':
             // Kusama - 0.1 KSM
             feeAmount = new BN(100000000000);
@@ -86,9 +86,11 @@ async function main () {
             break;
         default:
             const genesisHash = (await relayApi.genesisHash) as any;
-            if (genesisHash === '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443') {
+            console.log(genesisHash.toString().toLowerCase());
+            if (genesisHash.toString().toLowerCase() === '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443') {
                 //Moonbase Alpha Relay - 1 UNIT
-                feeAmount = new BN(1000000000000);   
+                feeAmount = new BN(1000000000000);
+                break; 
             }
 
             // We dont know what relay chain is this

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -1,80 +1,79 @@
 // Import
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { u8aToHex, hexToU8a } from '@polkadot/util';
-import { BN } from '@polkadot/util';
+import {u8aToHex, hexToU8a} from '@polkadot/util';
+import { BN } from "@polkadot/util";
 
-import { blake2AsHex, xxhashAsU8a, blake2AsU8a } from '@polkadot/util-crypto';
+import {blake2AsHex, xxhashAsU8a, blake2AsU8a} from '@polkadot/util-crypto';
 import yargs from 'yargs';
-import { Keyring } from '@polkadot/api';
+import { Keyring } from "@polkadot/api";
 import { ParaId } from '@polkadot/types/interfaces';
 
 const args = yargs.options({
-    'parachain-ws-provider': { type: 'string', demandOption: true, alias: 'wp' },
-    'relay-ws-provider': { type: 'string', demandOption: true, alias: 'wr' },
-    'hrmp-action': {
-        choices: ['accept', 'cancel', 'close', 'open'],
-        demandOption: true,
-        alias: 'hrmp',
-    },
-    'target-para-id': { type: 'number', demandOption: true, alias: 'p' },
-    'max-capacity': { type: 'number', demandOption: false, alias: 'mc' },
-    'max-message-size': { type: 'number', demandOption: false, alias: 'mms' },
-    'account-priv-key': { type: 'string', demandOption: false, alias: 'account' },
-    'send-preimage-hash': { type: 'boolean', demandOption: false, alias: 'h' },
-    'send-proposal-as': {
-        choices: ['democracy', 'council-external'],
-        demandOption: false,
-        alias: 's',
-    },
-    'collective-threshold': { type: 'number', demandOption: false, alias: 'c' },
-    'at-block': { type: 'number', demandOption: false },
-}).argv;
-
+    'parachain-ws-provider': {type: 'string', demandOption: true, alias: 'wp'},
+    'relay-ws-provider': {type: 'string', demandOption: true, alias: 'wr'},
+    'hrmp-action': {choices: ['accept', 'cancel', 'close', 'open'], demandOption: true, alias: 'hrmp'},
+    'target-para-id': {type: 'number', demandOption: true, alias: 'p'},
+    'max-capacity': {type: 'number', demandOption: false, alias: 'mc'},
+    'max-message-size': {type: 'number', demandOption: false, alias: 'mms'},
+    'account-priv-key': {type: 'string', demandOption: false, alias: 'account'},
+    'send-preimage-hash': {type: 'boolean', demandOption: false, alias: 'h'},
+    'send-proposal-as': {choices: ['democracy', 'council-external'], demandOption: false, alias: 's'},
+    'collective-threshold': {type: 'number', demandOption: false, alias: 'c'},
+    'at-block': {type: 'number', demandOption: false},
+  }).argv;
+ 
 // Construct
 const wsProvider = new WsProvider(args['parachain-ws-provider']);
 const relayProvider = new WsProvider(args['relay-ws-provider']);
 
-async function main() {
+async function main () {
     const api = await ApiPromise.create({ provider: wsProvider });
     const relayApi = await ApiPromise.create({ provider: relayProvider });
 
-    const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
+    const proposalAmount = await api.consts.democracy.minimumDeposit as any;
 
-    const collectiveThreshold = args['collective-threshold'] ? args['collective-threshold'] : 1;
+    const collectiveThreshold = (args['collective-threshold']) ? args['collective-threshold'] :1;
 
-    const keyring = new Keyring({ type: 'ethereum' });
-    const selfParaId: ParaId = (await api.query.parachainInfo.parachainId()) as any;
+    const keyring = new Keyring({ type: "ethereum" });
+    const selfParaId: ParaId = await api.query.parachainInfo.parachainId() as any;
 
     let relayCall;
-    if (args['hrmp-action'] == 'accept') {
-        relayCall = relayApi.tx.hrmp.hrmpAcceptOpenChannel(args['target-para-id']);
-    } else if (args['hrmp-action'] == 'open') {
+    if (args['hrmp-action'] == "accept") {
+        relayCall = relayApi.tx.hrmp.hrmpAcceptOpenChannel(
+            args["target-para-id"]
+        )
+    }
+    else if (args['hrmp-action'] == "open") {
         relayCall = relayApi.tx.hrmp.hrmpInitOpenChannel(
-            args['target-para-id'],
-            args['max-capacity'],
-            args['max-message-size']
-        );
-    } else if (args['hrmp-action'] == 'cancel') {
-        relayCall = relayApi.tx.hrmp.hrmpCancelOpenRequest({
-            sender: selfParaId,
-            recipient: args['target-para-id'],
-        });
-    } else {
-        relayCall = relayApi.tx.hrmp.hrmpCloseChannel({
-            sender: selfParaId,
-            recipient: args['target-para-id'],
-        });
+            args["target-para-id"],
+            args["max-capacity"],
+            args["max-message-size"]
+        )
+    }
+    else if (args['hrmp-action'] == "cancel") {
+        relayCall = relayApi.tx.hrmp.hrmpCancelOpenRequest(
+            {
+                sender: selfParaId,
+                recipient:  args["target-para-id"],
+            }
+        )
+    }
+    else {
+        relayCall = relayApi.tx.hrmp.hrmpCloseChannel(
+            {
+                sender: selfParaId,
+                recipient:  args["target-para-id"],
+            }
+        )
     }
 
-    let relayCall2 = relayCall?.method.toHex() || '';
+    let relayCall2 = relayCall?.method.toHex() || "";
     // Sovereign account is b"para" + encode(parahain ID) + trailling zeros
-    let para_address = u8aToHex(
-        new Uint8Array([...new TextEncoder().encode('para'), ...selfParaId.toU8a()])
-    ).padEnd(66, '0');
+    let para_address = u8aToHex((new Uint8Array([ ...new TextEncoder().encode("para"), ...selfParaId.toU8a()]))).padEnd(66, "0");
 
-    // Calculate fee amount
+    // get the chain information
     let feeAmount;
-    // Get decimals
+    // Get Decimals
     const relayChainInfo = (await relayApi.registry.getChainProperties()) as any;
     switch (relayChainInfo['tokenDecimals'].toHuman()[0]) {
         case '12':
@@ -87,99 +86,85 @@ async function main() {
             break;
         default:
             const genesisHash = (await relayApi.genesisHash) as any;
-            if (
-                genesisHash === '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443'
-            ) {
+            if (genesisHash === '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443') {
                 //Moonbase Alpha Relay - 1 UNIT
-                feeAmount = new BN(1000000000000);
+                feeAmount = new BN(1000000000000);   
             }
 
             // We dont know what relay chain is this
             throw new Error();
     }
 
-    const batchCall = api.tx.polkadotXcm.send(
-        { V1: { parents: new BN(1), interior: 'Here' } },
-        {
-            V2: [
-                {
-                    WithdrawAsset: [
-                        {
-                            id: { Concrete: { parents: new BN(0), interior: 'Here' } },
-                            fun: { Fungible: feeAmount },
-                        },
-                    ],
-                },
-                {
-                    BuyExecution: {
-                        fees: {
-                            id: { Concrete: { parents: new BN(0), interior: 'Here' } },
-                            fun: { Fungible: feeAmount },
-                        },
-                        weightLimit: { Limited: new BN(5000000000) },
+    const batchCall =  api.tx.polkadotXcm.send(
+        { V1: { parents: new BN(1), interior: "Here"} },
+        { V2: [
+            { WithdrawAsset: [
+                { id: { Concrete: { parents: new BN(0), interior: "Here"} },
+                  fun: { Fungible: feeAmount }
+                }
+            ]
+            },
+            { BuyExecution:  {
+                fees:
+                    { id: { Concrete: { parents: new BN(0), interior: "Here"} },
+                    fun: { Fungible: feeAmount }
                     },
-                },
-                {
-                    Transact: {
-                        originType: 'Native',
-                        requireWeightAtMost: new BN(1000000000),
-                        call: {
-                            encoded: relayCall2,
-                        },
-                    },
-                },
-                {
-                    DepositAsset: {
-                        assets: { Wild: 'All' },
-                        max_assets: 1,
-                        beneficiary: {
-                            parents: new BN(0),
-                            interior: { X1: { AccountId32: { network: 'Any', id: para_address } } },
-                        },
-                    },
-                },
-            ],
-        }
-    );
+                weightLimit: {Limited: new BN(5000000000)}
+                }
+            },
+            { Transact:  {
+                originType: "Native",
+                requireWeightAtMost: new BN(1000000000),
+                call: {
+                    encoded: relayCall2
+                   }
+                }
+            },
+            { DepositAsset:  {
+                assets: {Wild: "All"},
+                max_assets: 1,
+                beneficiary: { parents: new BN(0), interior: { X1: { AccountId32: { network: "Any", id: para_address } } }}
+                }
+            },
+            ]
+        });
 
-    console.log('Encoded proposal for PolkdotXcmSend is %s', batchCall.method.toHex() || '');
+    console.log("Encoded proposal for PolkdotXcmSend is %s", batchCall.method.toHex() || "");
 
-    const toPropose = args['at-block']
-        ? api.tx.scheduler.schedule(args['at-block'], null, 0, { Value: batchCall })
-        : batchCall;
+    const toPropose = args['at-block'] ? 
+        api.tx.scheduler.schedule(args["at-block"], null, 0, {Value: batchCall}) :
+        batchCall;
 
-    const account = await keyring.addFromUri(args['account-priv-key'], null, 'ethereum');
-    const { nonce: rawNonce, data: balance } = (await api.query.system.account(
-        account.address
-    )) as any;
+    const account =  await keyring.addFromUri(args['account-priv-key'], null, "ethereum");
+    const { nonce: rawNonce, data: balance } = await api.query.system.account(account.address) as any;
     let nonce = BigInt(rawNonce.toString());
 
     // We just prepare the proposals
-    let encodedProposal = toPropose?.method.toHex() || '';
+    let encodedProposal = toPropose?.method.toHex() || "";
     let encodedHash = blake2AsHex(encodedProposal);
-    console.log('Encoded proposal for batch utility after schedule is %s', encodedProposal);
-    console.log('Encoded proposal hash for batch utility after schedule is %s', encodedHash);
-    console.log('Encoded length %d', encodedProposal.length);
+    console.log("Encoded proposal for batch utility after schedule is %s", encodedProposal);
+    console.log("Encoded proposal hash for batch utility after schedule is %s", encodedHash);
+    console.log("Encoded length %d", encodedProposal.length);
 
-    if (args['send-preimage-hash']) {
+    if (args["send-preimage-hash"]) {
         await api.tx.democracy
-            .notePreimage(encodedProposal)
-            .signAndSend(account, { nonce: nonce++ });
+        .notePreimage(encodedProposal)
+        .signAndSend(account, { nonce: nonce++ });
 
-        if (args['send-proposal-as'] == 'democracy') {
+        if (args["send-proposal-as"] == 'democracy') {
             await api.tx.democracy
-                .propose(encodedHash, proposalAmount)
-                .signAndSend(account, { nonce: nonce++ });
-        } else if (args['send-proposal-as'] == 'council-external') {
-            let external = api.tx.democracy.externalProposeMajority(encodedHash);
-
+            .propose(encodedHash, proposalAmount)
+            .signAndSend(account, { nonce: nonce++ });
+        }
+        else if (args["send-proposal-as"] == 'council-external') {
+            let external =  api.tx.democracy.externalProposeMajority(encodedHash)
+            
             await api.tx.councilCollective
-                .propose(collectiveThreshold, external, external.length)
-                .signAndSend(account, { nonce: nonce++ });
+            .propose(collectiveThreshold, external, external.length)
+            .signAndSend(account, { nonce: nonce++ });
         }
     }
 }
 
-main()
-    .catch(console.error)
-    .finally(() => process.exit());
+
+main().catch(console.error).finally(() => process.exit());

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -1,162 +1,176 @@
 // Import
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import {u8aToHex, hexToU8a} from '@polkadot/util';
-import { BN } from "@polkadot/util";
+import { u8aToHex, hexToU8a } from '@polkadot/util';
+import { BN } from '@polkadot/util';
 
-import {blake2AsHex, xxhashAsU8a, blake2AsU8a} from '@polkadot/util-crypto';
+import { blake2AsHex, xxhashAsU8a, blake2AsU8a } from '@polkadot/util-crypto';
 import yargs from 'yargs';
-import { Keyring } from "@polkadot/api";
+import { Keyring } from '@polkadot/api';
 import { ParaId } from '@polkadot/types/interfaces';
 
 const args = yargs.options({
-    'parachain-ws-provider': {type: 'string', demandOption: true, alias: 'wp'},
-    'relay-ws-provider': {type: 'string', demandOption: true, alias: 'wr'},
-    'hrmp-action': {choices: ['accept', 'cancel', 'close', 'open'], demandOption: true, alias: 'hrmp'},
-    'target-para-id': {type: 'number', demandOption: true, alias: 'p'},
-    'max-capacity': {type: 'number', demandOption: false, alias: 'mc'},
-    'max-message-size': {type: 'number', demandOption: false, alias: 'mms'},
-    'account-priv-key': {type: 'string', demandOption: false, alias: 'account'},
-    'send-preimage-hash': {type: 'boolean', demandOption: false, alias: 'h'},
-    'send-proposal-as': {choices: ['democracy', 'council-external'], demandOption: false, alias: 's'},
-    'collective-threshold': {type: 'number', demandOption: false, alias: 'c'},
-    'at-block': {type: 'number', demandOption: false},
-  }).argv;
- 
+  'parachain-ws-provider': { type: 'string', demandOption: true, alias: 'wp' },
+  'relay-ws-provider': { type: 'string', demandOption: true, alias: 'wr' },
+  'hrmp-action': {
+    choices: ['accept', 'cancel', 'close', 'open'],
+    demandOption: true,
+    alias: 'hrmp',
+  },
+  'target-para-id': { type: 'number', demandOption: true, alias: 'p' },
+  'max-capacity': { type: 'number', demandOption: false, alias: 'mc' },
+  'max-message-size': { type: 'number', demandOption: false, alias: 'mms' },
+  'account-priv-key': { type: 'string', demandOption: false, alias: 'account' },
+  'send-preimage-hash': { type: 'boolean', demandOption: false, alias: 'h' },
+  'send-proposal-as': {
+    choices: ['democracy', 'council-external'],
+    demandOption: false,
+    alias: 's',
+  },
+  'collective-threshold': { type: 'number', demandOption: false, alias: 'c' },
+  'at-block': { type: 'number', demandOption: false },
+}).argv;
+
 // Construct
 const wsProvider = new WsProvider(args['parachain-ws-provider']);
 const relayProvider = new WsProvider(args['relay-ws-provider']);
 
-async function main () {
-    const api = await ApiPromise.create({ provider: wsProvider });
-    const relayApi = await ApiPromise.create({ provider: relayProvider });
+async function main() {
+  const api = await ApiPromise.create({ provider: wsProvider });
+  const relayApi = await ApiPromise.create({ provider: relayProvider });
 
-    const proposalAmount = await api.consts.democracy.minimumDeposit as any;
+  const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
 
-    const collectiveThreshold = (args['collective-threshold']) ? args['collective-threshold'] :1;
+  const collectiveThreshold = args['collective-threshold'] ? args['collective-threshold'] : 1;
 
-    const keyring = new Keyring({ type: "ethereum" });
-    const selfParaId: ParaId = await api.query.parachainInfo.parachainId() as any;
+  const keyring = new Keyring({ type: 'ethereum' });
+  const selfParaId: ParaId = (await api.query.parachainInfo.parachainId()) as any;
 
-    let relayCall;
-    if (args['hrmp-action'] == "accept") {
-        relayCall = relayApi.tx.hrmp.hrmpAcceptOpenChannel(
-            args["target-para-id"]
-        )
-    }
-    else if (args['hrmp-action'] == "open") {
-        relayCall = relayApi.tx.hrmp.hrmpInitOpenChannel(
-            args["target-para-id"],
-            args["max-capacity"],
-            args["max-message-size"]
-        )
-    }
-    else if (args['hrmp-action'] == "cancel") {
-        relayCall = relayApi.tx.hrmp.hrmpCancelOpenRequest(
+  let relayCall;
+  if (args['hrmp-action'] == 'accept') {
+    relayCall = relayApi.tx.hrmp.hrmpAcceptOpenChannel(args['target-para-id']);
+  } else if (args['hrmp-action'] == 'open') {
+    relayCall = relayApi.tx.hrmp.hrmpInitOpenChannel(
+      args['target-para-id'],
+      args['max-capacity'],
+      args['max-message-size']
+    );
+  } else if (args['hrmp-action'] == 'cancel') {
+    relayCall = relayApi.tx.hrmp.hrmpCancelOpenRequest({
+      sender: selfParaId,
+      recipient: args['target-para-id'],
+    });
+  } else {
+    relayCall = relayApi.tx.hrmp.hrmpCloseChannel({
+      sender: selfParaId,
+      recipient: args['target-para-id'],
+    });
+  }
+
+  let relayCall2 = relayCall?.method.toHex() || '';
+  // Sovereign account is b"para" + encode(parahain ID) + trailling zeros
+  let para_address = u8aToHex(
+    new Uint8Array([...new TextEncoder().encode('para'), ...selfParaId.toU8a()])
+  ).padEnd(66, '0');
+
+  // get the chain information
+  let feeAmount;
+  const genesisHash = (await relayApi.genesisHash) as any;
+  switch (genesisHash.toString()) {
+    case '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443':
+      //Moonbase Alpha Relay - 1 UNIT
+      feeAmount = new BN(1000000000000);
+      break;
+    case '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe':
+      // Kusama - 1 KSM
+      feeAmount = new BN(1000000000000);
+    case '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3':
+      // Polkadot - 10 DOT
+      feeAmount = new BN(100000000000);
+    default:
+      // We dont know what relay chain is this
+      throw new Error();
+  }
+
+  const batchCall = api.tx.polkadotXcm.send(
+    { V1: { parents: new BN(1), interior: 'Here' } },
+    {
+      V2: [
+        {
+          WithdrawAsset: [
             {
-                sender: selfParaId,
-                recipient:  args["target-para-id"],
-            }
-        )
-    }
-    else {
-        relayCall = relayApi.tx.hrmp.hrmpCloseChannel(
-            {
-                sender: selfParaId,
-                recipient:  args["target-para-id"],
-            }
-        )
-    }
-
-    let relayCall2 = relayCall?.method.toHex() || "";
-    // Sovereign account is b"para" + encode(parahain ID) + trailling zeros
-    let para_address = u8aToHex((new Uint8Array([ ...new TextEncoder().encode("para"), ...selfParaId.toU8a()]))).padEnd(66, "0");
-
-    // get the chain information
-    const relayChainInfo = (await relayApi.registry.getChainProperties()) as any;
-    let feeAmount;
-    if (relayChainInfo['tokenDecimals'].toHuman()[0] == '12') {
-        // 1 KSM
-        feeAmount = new BN(1000000000000)
-    }
-    else if (relayChainInfo['tokenDecimals'].toHuman()[0] == '10') {
-        // 10 DOT
-        feeAmount = new BN(100000000000)       
-    }
-    else {
-        // We dont know what relay chain is this
-        throw new Error()
-    }
-
-    const batchCall =  api.tx.polkadotXcm.send(
-        { V1: { parents: new BN(1), interior: "Here"} },
-        { V2: [
-            { WithdrawAsset: [
-                { id: { Concrete: { parents: new BN(0), interior: "Here"} },
-                  fun: { Fungible: feeAmount }
-                }
-            ]
+              id: { Concrete: { parents: new BN(0), interior: 'Here' } },
+              fun: { Fungible: feeAmount },
             },
-            { BuyExecution:  {
-                fees:
-                    { id: { Concrete: { parents: new BN(0), interior: "Here"} },
-                    fun: { Fungible: feeAmount }
-                    },
-                weightLimit: {Limited: new BN(5000000000)}
-                }
+          ],
+        },
+        {
+          BuyExecution: {
+            fees: {
+              id: { Concrete: { parents: new BN(0), interior: 'Here' } },
+              fun: { Fungible: feeAmount },
             },
-            { Transact:  {
-                originType: "Native",
-                requireWeightAtMost: new BN(1000000000),
-                call: {
-                    encoded: relayCall2
-                   }
-                }
+            weightLimit: { Limited: new BN(5000000000) },
+          },
+        },
+        {
+          Transact: {
+            originType: 'Native',
+            requireWeightAtMost: new BN(1000000000),
+            call: {
+              encoded: relayCall2,
             },
-            { DepositAsset:  {
-                assets: {Wild: "All"},
-                max_assets: 1,
-                beneficiary: { parents: new BN(0), interior: { X1: { AccountId32: { network: "Any", id: para_address } } }}
-                }
+          },
+        },
+        {
+          DepositAsset: {
+            assets: { Wild: 'All' },
+            max_assets: 1,
+            beneficiary: {
+              parents: new BN(0),
+              interior: { X1: { AccountId32: { network: 'Any', id: para_address } } },
             },
-            ]
-        });
+          },
+        },
+      ],
+    }
+  );
 
-    console.log("Encoded proposal for PolkdotXcmSend is %s", batchCall.method.toHex() || "");
+  console.log('Encoded proposal for PolkdotXcmSend is %s', batchCall.method.toHex() || '');
 
-    const toPropose = args['at-block'] ? 
-        api.tx.scheduler.schedule(args["at-block"], null, 0, {Value: batchCall}) :
-        batchCall;
+  const toPropose = args['at-block']
+    ? api.tx.scheduler.schedule(args['at-block'], null, 0, { Value: batchCall })
+    : batchCall;
 
-    const account =  await keyring.addFromUri(args['account-priv-key'], null, "ethereum");
-    const { nonce: rawNonce, data: balance } = await api.query.system.account(account.address) as any;
-    let nonce = BigInt(rawNonce.toString());
+  const account = await keyring.addFromUri(args['account-priv-key'], null, 'ethereum');
+  const { nonce: rawNonce, data: balance } = (await api.query.system.account(
+    account.address
+  )) as any;
+  let nonce = BigInt(rawNonce.toString());
 
-    // We just prepare the proposals
-    let encodedProposal = toPropose?.method.toHex() || "";
-    let encodedHash = blake2AsHex(encodedProposal);
-    console.log("Encoded proposal for batch utility after schedule is %s", encodedProposal);
-    console.log("Encoded proposal hash for batch utility after schedule is %s", encodedHash);
-    console.log("Encoded length %d", encodedProposal.length);
+  // We just prepare the proposals
+  let encodedProposal = toPropose?.method.toHex() || '';
+  let encodedHash = blake2AsHex(encodedProposal);
+  console.log('Encoded proposal for batch utility after schedule is %s', encodedProposal);
+  console.log('Encoded proposal hash for batch utility after schedule is %s', encodedHash);
+  console.log('Encoded length %d', encodedProposal.length);
 
-    if (args["send-preimage-hash"]) {
-        await api.tx.democracy
-        .notePreimage(encodedProposal)
+  if (args['send-preimage-hash']) {
+    await api.tx.democracy.notePreimage(encodedProposal).signAndSend(account, { nonce: nonce++ });
+
+    if (args['send-proposal-as'] == 'democracy') {
+      await api.tx.democracy
+        .propose(encodedHash, proposalAmount)
         .signAndSend(account, { nonce: nonce++ });
+    } else if (args['send-proposal-as'] == 'council-external') {
+      let external = api.tx.democracy.externalProposeMajority(encodedHash);
 
-        if (args["send-proposal-as"] == 'democracy') {
-            await api.tx.democracy
-            .propose(encodedHash, proposalAmount)
-            .signAndSend(account, { nonce: nonce++ });
-        }
-        else if (args["send-proposal-as"] == 'council-external') {
-            let external =  api.tx.democracy.externalProposeMajority(encodedHash)
-            
-            await api.tx.councilCollective
-            .propose(collectiveThreshold, external, external.length)
-            .signAndSend(account, { nonce: nonce++ });
-        }
+      await api.tx.councilCollective
+        .propose(collectiveThreshold, external, external.length)
+        .signAndSend(account, { nonce: nonce++ });
     }
+  }
 }
 
-
-main().catch(console.error).finally(() => process.exit());
+main()
+  .catch(console.error)
+  .finally(() => process.exit());

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -80,12 +80,12 @@ async function main () {
             feeAmount = new BN(1000000000000);
             break;
         case '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe':
-            // Kusama - 1 KSM
-            feeAmount = new BN(1000000000000);
+            // Kusama - 0.1 KSM
+            feeAmount = new BN(100000000000);
             break;
         case '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3':
-            // Polkadot - 10 DOT
-            feeAmount = new BN(100000000000);
+            // Polkadot - 1 DOT
+            feeAmount = new BN(10000000000);
             break;
         default:
             // We dont know what relay chain is this

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -1,167 +1,185 @@
 // Import
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import {u8aToHex, hexToU8a} from '@polkadot/util';
-import { BN } from "@polkadot/util";
+import { u8aToHex, hexToU8a } from '@polkadot/util';
+import { BN } from '@polkadot/util';
 
-import {blake2AsHex, xxhashAsU8a, blake2AsU8a} from '@polkadot/util-crypto';
+import { blake2AsHex, xxhashAsU8a, blake2AsU8a } from '@polkadot/util-crypto';
 import yargs from 'yargs';
-import { Keyring } from "@polkadot/api";
+import { Keyring } from '@polkadot/api';
 import { ParaId } from '@polkadot/types/interfaces';
 
 const args = yargs.options({
-    'parachain-ws-provider': {type: 'string', demandOption: true, alias: 'wp'},
-    'relay-ws-provider': {type: 'string', demandOption: true, alias: 'wr'},
-    'hrmp-action': {choices: ['accept', 'cancel', 'close', 'open'], demandOption: true, alias: 'hrmp'},
-    'target-para-id': {type: 'number', demandOption: true, alias: 'p'},
-    'max-capacity': {type: 'number', demandOption: false, alias: 'mc'},
-    'max-message-size': {type: 'number', demandOption: false, alias: 'mms'},
-    'account-priv-key': {type: 'string', demandOption: false, alias: 'account'},
-    'send-preimage-hash': {type: 'boolean', demandOption: false, alias: 'h'},
-    'send-proposal-as': {choices: ['democracy', 'council-external'], demandOption: false, alias: 's'},
-    'collective-threshold': {type: 'number', demandOption: false, alias: 'c'},
-    'at-block': {type: 'number', demandOption: false},
-  }).argv;
- 
+    'parachain-ws-provider': { type: 'string', demandOption: true, alias: 'wp' },
+    'relay-ws-provider': { type: 'string', demandOption: true, alias: 'wr' },
+    'hrmp-action': {
+        choices: ['accept', 'cancel', 'close', 'open'],
+        demandOption: true,
+        alias: 'hrmp',
+    },
+    'target-para-id': { type: 'number', demandOption: true, alias: 'p' },
+    'max-capacity': { type: 'number', demandOption: false, alias: 'mc' },
+    'max-message-size': { type: 'number', demandOption: false, alias: 'mms' },
+    'account-priv-key': { type: 'string', demandOption: false, alias: 'account' },
+    'send-preimage-hash': { type: 'boolean', demandOption: false, alias: 'h' },
+    'send-proposal-as': {
+        choices: ['democracy', 'council-external'],
+        demandOption: false,
+        alias: 's',
+    },
+    'collective-threshold': { type: 'number', demandOption: false, alias: 'c' },
+    'at-block': { type: 'number', demandOption: false },
+}).argv;
+
 // Construct
 const wsProvider = new WsProvider(args['parachain-ws-provider']);
 const relayProvider = new WsProvider(args['relay-ws-provider']);
 
-async function main () {
+async function main() {
     const api = await ApiPromise.create({ provider: wsProvider });
     const relayApi = await ApiPromise.create({ provider: relayProvider });
 
-    const proposalAmount = await api.consts.democracy.minimumDeposit as any;
+    const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
 
-    const collectiveThreshold = (args['collective-threshold']) ? args['collective-threshold'] :1;
+    const collectiveThreshold = args['collective-threshold'] ? args['collective-threshold'] : 1;
 
-    const keyring = new Keyring({ type: "ethereum" });
-    const selfParaId: ParaId = await api.query.parachainInfo.parachainId() as any;
+    const keyring = new Keyring({ type: 'ethereum' });
+    const selfParaId: ParaId = (await api.query.parachainInfo.parachainId()) as any;
 
     let relayCall;
-    if (args['hrmp-action'] == "accept") {
-        relayCall = relayApi.tx.hrmp.hrmpAcceptOpenChannel(
-            args["target-para-id"]
-        )
-    }
-    else if (args['hrmp-action'] == "open") {
+    if (args['hrmp-action'] == 'accept') {
+        relayCall = relayApi.tx.hrmp.hrmpAcceptOpenChannel(args['target-para-id']);
+    } else if (args['hrmp-action'] == 'open') {
         relayCall = relayApi.tx.hrmp.hrmpInitOpenChannel(
-            args["target-para-id"],
-            args["max-capacity"],
-            args["max-message-size"]
-        )
-    }
-    else if (args['hrmp-action'] == "cancel") {
-        relayCall = relayApi.tx.hrmp.hrmpCancelOpenRequest(
-            {
-                sender: selfParaId,
-                recipient:  args["target-para-id"],
-            }
-        )
-    }
-    else {
-        relayCall = relayApi.tx.hrmp.hrmpCloseChannel(
-            {
-                sender: selfParaId,
-                recipient:  args["target-para-id"],
-            }
-        )
+            args['target-para-id'],
+            args['max-capacity'],
+            args['max-message-size']
+        );
+    } else if (args['hrmp-action'] == 'cancel') {
+        relayCall = relayApi.tx.hrmp.hrmpCancelOpenRequest({
+            sender: selfParaId,
+            recipient: args['target-para-id'],
+        });
+    } else {
+        relayCall = relayApi.tx.hrmp.hrmpCloseChannel({
+            sender: selfParaId,
+            recipient: args['target-para-id'],
+        });
     }
 
-    let relayCall2 = relayCall?.method.toHex() || "";
+    let relayCall2 = relayCall?.method.toHex() || '';
     // Sovereign account is b"para" + encode(parahain ID) + trailling zeros
-    let para_address = u8aToHex((new Uint8Array([ ...new TextEncoder().encode("para"), ...selfParaId.toU8a()]))).padEnd(66, "0");
+    let para_address = u8aToHex(
+        new Uint8Array([...new TextEncoder().encode('para'), ...selfParaId.toU8a()])
+    ).padEnd(66, '0');
 
-    // get the chain information
+    // Calculate fee amount
     let feeAmount;
-    const genesisHash = (await relayApi.genesisHash) as any;
-    switch (genesisHash.toString().toLowerCase()) {
-        case '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443':
-            //Moonbase Alpha Relay - 1 UNIT
-            feeAmount = new BN(1000000000000);
-            break;
-        case '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe':
+    // Get decimals
+    const relayChainInfo = (await relayApi.registry.getChainProperties()) as any;
+    switch (relayChainInfo['tokenDecimals'].toHuman()[0]) {
+        case '12':
             // Kusama - 0.1 KSM
             feeAmount = new BN(100000000000);
             break;
-        case '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3':
+        case '10':
             // Polkadot - 1 DOT
             feeAmount = new BN(10000000000);
             break;
         default:
+            const genesisHash = (await relayApi.genesisHash) as any;
+            if (
+                genesisHash === '0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443'
+            ) {
+                //Moonbase Alpha Relay - 1 UNIT
+                feeAmount = new BN(1000000000000);
+            }
+
             // We dont know what relay chain is this
             throw new Error();
     }
 
-    const batchCall =  api.tx.polkadotXcm.send(
-        { V1: { parents: new BN(1), interior: "Here"} },
-        { V2: [
-            { WithdrawAsset: [
-                { id: { Concrete: { parents: new BN(0), interior: "Here"} },
-                  fun: { Fungible: feeAmount }
-                }
-            ]
-            },
-            { BuyExecution:  {
-                fees:
-                    { id: { Concrete: { parents: new BN(0), interior: "Here"} },
-                    fun: { Fungible: feeAmount }
+    const batchCall = api.tx.polkadotXcm.send(
+        { V1: { parents: new BN(1), interior: 'Here' } },
+        {
+            V2: [
+                {
+                    WithdrawAsset: [
+                        {
+                            id: { Concrete: { parents: new BN(0), interior: 'Here' } },
+                            fun: { Fungible: feeAmount },
+                        },
+                    ],
+                },
+                {
+                    BuyExecution: {
+                        fees: {
+                            id: { Concrete: { parents: new BN(0), interior: 'Here' } },
+                            fun: { Fungible: feeAmount },
+                        },
+                        weightLimit: { Limited: new BN(5000000000) },
                     },
-                weightLimit: {Limited: new BN(5000000000)}
-                }
-            },
-            { Transact:  {
-                originType: "Native",
-                requireWeightAtMost: new BN(1000000000),
-                call: {
-                    encoded: relayCall2
-                   }
-                }
-            },
-            { DepositAsset:  {
-                assets: {Wild: "All"},
-                max_assets: 1,
-                beneficiary: { parents: new BN(0), interior: { X1: { AccountId32: { network: "Any", id: para_address } } }}
-                }
-            },
-            ]
-        });
+                },
+                {
+                    Transact: {
+                        originType: 'Native',
+                        requireWeightAtMost: new BN(1000000000),
+                        call: {
+                            encoded: relayCall2,
+                        },
+                    },
+                },
+                {
+                    DepositAsset: {
+                        assets: { Wild: 'All' },
+                        max_assets: 1,
+                        beneficiary: {
+                            parents: new BN(0),
+                            interior: { X1: { AccountId32: { network: 'Any', id: para_address } } },
+                        },
+                    },
+                },
+            ],
+        }
+    );
 
-    console.log("Encoded proposal for PolkdotXcmSend is %s", batchCall.method.toHex() || "");
+    console.log('Encoded proposal for PolkdotXcmSend is %s', batchCall.method.toHex() || '');
 
-    const toPropose = args['at-block'] ? 
-        api.tx.scheduler.schedule(args["at-block"], null, 0, {Value: batchCall}) :
-        batchCall;
+    const toPropose = args['at-block']
+        ? api.tx.scheduler.schedule(args['at-block'], null, 0, { Value: batchCall })
+        : batchCall;
 
-    const account =  await keyring.addFromUri(args['account-priv-key'], null, "ethereum");
-    const { nonce: rawNonce, data: balance } = await api.query.system.account(account.address) as any;
+    const account = await keyring.addFromUri(args['account-priv-key'], null, 'ethereum');
+    const { nonce: rawNonce, data: balance } = (await api.query.system.account(
+        account.address
+    )) as any;
     let nonce = BigInt(rawNonce.toString());
 
     // We just prepare the proposals
-    let encodedProposal = toPropose?.method.toHex() || "";
+    let encodedProposal = toPropose?.method.toHex() || '';
     let encodedHash = blake2AsHex(encodedProposal);
-    console.log("Encoded proposal for batch utility after schedule is %s", encodedProposal);
-    console.log("Encoded proposal hash for batch utility after schedule is %s", encodedHash);
-    console.log("Encoded length %d", encodedProposal.length);
+    console.log('Encoded proposal for batch utility after schedule is %s', encodedProposal);
+    console.log('Encoded proposal hash for batch utility after schedule is %s', encodedHash);
+    console.log('Encoded length %d', encodedProposal.length);
 
-    if (args["send-preimage-hash"]) {
+    if (args['send-preimage-hash']) {
         await api.tx.democracy
-        .notePreimage(encodedProposal)
-        .signAndSend(account, { nonce: nonce++ });
+            .notePreimage(encodedProposal)
+            .signAndSend(account, { nonce: nonce++ });
 
-        if (args["send-proposal-as"] == 'democracy') {
+        if (args['send-proposal-as'] == 'democracy') {
             await api.tx.democracy
-            .propose(encodedHash, proposalAmount)
-            .signAndSend(account, { nonce: nonce++ });
-        }
-        else if (args["send-proposal-as"] == 'council-external') {
-            let external =  api.tx.democracy.externalProposeMajority(encodedHash)
-            
+                .propose(encodedHash, proposalAmount)
+                .signAndSend(account, { nonce: nonce++ });
+        } else if (args['send-proposal-as'] == 'council-external') {
+            let external = api.tx.democracy.externalProposeMajority(encodedHash);
+
             await api.tx.councilCollective
-            .propose(collectiveThreshold, external, external.length)
-            .signAndSend(account, { nonce: nonce++ });
+                .propose(collectiveThreshold, external, external.length)
+                .signAndSend(account, { nonce: nonce++ });
         }
     }
 }
 
-
-main().catch(console.error).finally(() => process.exit());
+main()
+    .catch(console.error)
+    .finally(() => process.exit());


### PR DESCRIPTION
There was a weird bug when retrieving the decimals of the Alphanet Relay. Consequently, I've changed the script to use the relay genesis hash instead for Alphanet Relay.

This PR also lowers the fees for KSM (to 0.1 KSM) and DOT (to 1 DOT) when transacting on the relay chain