### PR TITLE
Changes the democacyWrapper for OpenGovV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The script accepts these inputs fields:
 - `--revert-code` or `--revert`, boolean specifying whether we want register the revert code in the evm
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash    
-- `--send-proposal-as` or `-s`, optional, but if providede needs to be "democracy" or "council-external" specifying whether we want to send the proposal through regular democracy or as an external proposal that will be voted by the council
+- `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
 - `--collective-threshold` or `-c`, Optional, number specifying the number of council votes that need to aprove the proposal. If not provided defautls to 1.
 - `--at-block`, Optional, number specifying the block number at which the call should get executed.
 
@@ -65,8 +65,10 @@ The script accepts these inputs fields:
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
-- `--send-proposal-as` or `-s`, optional, but if providede needs to be "democracy" or "council-external" specifying whether we want to send the proposal through regular democracy or as an external proposal that will be voted by the council
+- `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
 - `--collective-threshold` or `-c`, Optional, number specifying the number of council votes that need to aprove the proposal. If not provided defautls to 1.
+- `--delay`, Optional, number of blocks to delay an OpenGovV2 proposal's execution by
+- `--track`, Optional, the JSON encoded origin for an OpenGovV2 proposal. For Moonbeam networks: "root", "whitelisted", "general", "canceller", "killer"
 - `--at-block`, Optional, number specifying the block number at which the call should get executed.
 
 ### Example to note Pre-Image and propose
@@ -91,7 +93,9 @@ The script accepts these inputs fields:
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
-- `--send-proposal-as` or `-s`, optional, but if providede needs to be "democracy" or "council-external" specifying whether we want to send the proposal through regular democracy or as an external proposal that will be voted by the council
+- `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
+- `--delay`, Optional, number of blocks to delay an OpenGovV2 proposal's execution by
+- `--track`, Optional, the JSON encoded origin for an OpenGovV2 proposal. For Moonbeam networks: "root", "whitelisted", "general", "canceller", "killer"
 - `--collective-threshold` or `-c`, Optional, number specifying the number of council votes that need to aprove the proposal. If not provided defautls to 1.
 - `--at-block`, Optional, number specifying the block number at which the call should get executed.
 
@@ -122,6 +126,8 @@ The script accepts these inputs fields:
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
 - `--send-proposal` or `-s`, optional, but if providede needs to be "democracy" or "council-external" specifying whether we want to send the proposal through regular democracy or as an external proposal that will be voted by the council
 - `--collective-threshold` or `-c`, Optional, number specifying the number of council votes that need to aprove the proposal. If not provided defautls to 1.
+- `--delay`, Optional, number of blocks to delay an OpenGovV2 proposal's execution by
+- `--track`, Optional, the JSON encoded origin for an OpenGovV2 proposal. For Moonbeam networks: "root", "whitelisted", "general", "canceller", "killer"
 - `--at-block`, Optional, number specifying the block number at which the call should get executed.
 
 ### Example to note Pre-Image and propose
@@ -145,8 +151,10 @@ The script accepts these inputs fields:
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
-- `--send-proposal-as` or `-s`, optional, but if providede needs to be "democracy" or "council-external" specifying whether we want to send the proposal through regular democracy or as an external proposal that will be voted by the council
+- `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
 - `--collective-threshold` or `-c`, Optional, number specifying the number of council votes that need to aprove the proposal. If not provided defautls to 1.
+- `--delay`, Optional, number of blocks to delay an OpenGovV2 proposal's execution by
+- `--track`, Optional, the JSON encoded origin for an OpenGovV2 proposal. For Moonbeam networks: "root", "whitelisted", "general", "canceller", "killer"
 - `--at-block`, Optional, number specifying the block number at which the call should get executed.
 
 ### Example to note Pre-Image and propose
@@ -173,8 +181,10 @@ The script accepts these inputs fields:
 - `--account-priv-key` or `-a`, which specifies the account that will submit the preimage
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
-- `--send-proposal-as` or `-s`, optional, but if providede needs to be "democracy" or "council-external" specifying whether we want to send the proposal through regular democracy or as an external proposal that will be voted by the council
+- `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
 - `--collective-threshold` or `-c`, Optional, number specifying the number of council votes that need to aprove the proposal. If not provided defautls to 1.
+- `--delay`, Optional, number of blocks to delay an OpenGovV2 proposal's execution by
+- `--track`, Optional, the JSON encoded origin for an OpenGovV2 proposal. For Moonbeam networks: "root", "whitelisted", "general", "canceller", "killer"
 - `--at-block`, Optional, number specifying the block number at which the call should get executed.
 
 ### Example to note Pre-Image with external account
@@ -199,8 +209,10 @@ The script accepts these inputs fields:
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash
-- `--send-proposal-as` or `-s`, optional, but if providede needs to be "democracy" or "council-external" specifying whether we want to send the proposal through regular democracy or as an external proposal that will be voted by the council
+- `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
 - `--collective-threshold` or `-c`, Optional, number specifying the number of council votes that need to aprove the proposal. If not provided defautls to 1.
+- `--delay`, Optional, number of blocks to delay an OpenGovV2 proposal's execution by
+- `--track`, Optional, the JSON encoded origin for an OpenGovV2 proposal. For Moonbeam networks: "root", "whitelisted", "general", "canceller", "killer"
 - `--at-block`, Optional, number specifying the block number at which the call should get executed.
 
 ### Example through democracy
@@ -334,6 +346,8 @@ The script accepts these inputs fields:
 - `--bew-para-id or -p`, The new paraId.
 - `--account-priv-key or -a`, which specifies the account that will submit the proposal
 - `--send-preimage-hash or -h`, boolean specifying whether we want to send the preimage hash
-- `--send-proposal-as or -s`, optional, but if providede needs to be "democracy" or "council-external" specifying whether we want to send the proposal through regular democracy or as an external proposal that will be voted by the council
+- `--send-proposal-as` or `-s`, optional, but if provided needs to be "democracy", "council-external", or "v2" specifying whether we want to send the proposal through regular democracy, as an external proposal that will be voted by the council, or through OpenGovV2
 - `--collective-threshold or -c`, Optional, number specifying the number of council votes that need to aprove the proposal. If not provided defautls to 1.
+- `--delay`, Optional, number of blocks to delay an OpenGovV2 proposal's execution by
+- `--track`, Optional, the JSON encoded origin for an OpenGovV2 proposal. For Moonbeam networks: "root", "whitelisted", "general", "canceller", "killer"
 - `--at-block`, Optional, number specifying the block number at which the call should get executed.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ The script accepts these inputs fields:
 
 `yarn register-asset -w ws://127.0.0.1:34102  --asset  '{ "parents": 1, "interior": "Here" }' -u 1 --name "Parent" --sym "DOT" -d 12 --ed 1 --sufficient true --account-priv-key "0x8075991ce870b93a8870eca0c0f91913d12f47948ca0fd25b49c6fa7cdbeee8b" -h true -s council-external -c 2`
 
+### Example to note Pre-Image and propose through OpenGov2 with custom track
+
+`yarn register-asset -s v2 --track '{ "Origins": "YourCustomOrigin" }' -w ws://127.0.0.1:9944  --asset  '{ "parents": 1, "interior": "Here" }' -u 1 --name "DOT" --sym "DOT" -d 12 --ed 1 --sufficient true --account-priv-key "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133" -h true --revert-code true`
+
+The `track` field must be a JSON formatted representation of the `referenda.submit` extrinsic's `proposalOrigin` input.  
+
 ## XCM-initializer script
 
 Script that allows to initialize XCM in a Moonbeam runtime. It particularly does:
@@ -79,6 +85,12 @@ The script accepts these inputs fields:
 
 `yarn initialize-xcm --ws-provider ws://127.0.0.1:34102  --default-xcm-version 2 --xcm-transactor-address "0x0000000000000000000000000000000000000806" --xtokens-address "0x0000000000000000000000000000000000000804" --account-priv-key "0x8075991ce870b93a8870eca0c0f91913d12f47948ca0fd25b49c6fa7cdbeee8b" --send-preimage-hash true --send-proposal-as council-external --collective-threshold 2`
 
+### Example to note Pre-Image and propose through OpenGov2 with custom track
+
+`yarn initialize-xcm -s v2 --track '{ "Origins": "YourCustomOrigin" }' --ws-provider ws://127.0.0.1:34102  --default-xcm-version 2 --xcm-transactor-address "0x0000000000000000000000000000000000000806" --xtokens-address "0x0000000000000000000000000000000000000804" --account-priv-key "0x8075991ce870b93a8870eca0c0f91913d12f47948ca0fd25b49c6fa7cdbeee8b" --send-preimage-hash true`
+
+The `track` field must be a JSON formatted representation of the `referenda.submit` extrinsic's `proposalOrigin` input.  
+
 ## HRMP-manipulator script
 
 Script that allows to initiate an HRMP action in the relay from the parachain. In particular, the script allows to open a channel, accept an existing open channel request, cancel an existing open channel request, or closing an existing HRMP channel.
@@ -108,6 +120,12 @@ The script accepts these inputs fields:
 `yarn hrmp-manipulator --parachain-ws-provider ws://127.0.0.1:34102  --relay-ws-provider ws://127.0.0.1:34002 --hrmp-action accept --target-para-id 2003 --account-priv-key "0x8075991ce870b93a8870eca0c0f91913d12f47948ca0fd25b49c6fa7cdbeee8b" --send-preimage-hash true  --send-proposal-as council-external -c 2`
 
 `yarn hrmp-manipulator --parachain-ws-provider ws://127.0.0.1:34102  --relay-ws-provider ws://127.0.0.1:34002 --hrmp-action open --target-para-id 2003 --mc 8 --mms 512 --account-priv-key "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133" --send-preimage-hash true --send-proposal-as democracy`
+
+### Example to note Pre-Image and propose through OpenGov2 with custom track
+
+`yarn hrmp-manipulator -s v2 --track '{ "Origins": "YourCustomOrigin" }' --parachain-ws-provider ws://127.0.0.1:34102  --relay-ws-provider ws://127.0.0.1:34002 --hrmp-action accept --target-para-id 2003 --account-priv-key "0x8075991ce870b93a8870eca0c0f91913d12f47948ca0fd25b49c6fa7cdbeee8b" --send-preimage-hash true`
+
+The `track` field must be a JSON formatted representation of the `referenda.submit` extrinsic's `proposalOrigin` input.  
 
 ## XCM-transactor-info-setter script
 
@@ -139,6 +157,12 @@ The script accepts these inputs fields:
 ### Example to note Pre-Image and propose through democracy with index registration
 `yarn set-transact-info --ws-provider ws://127.0.0.1:34102  --destination  '{ "parents": 1, "interior": "Here" }' --fee-per-second 8 --extra-weight 3000000000 --max-weight 20000000000 --account-priv-key "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133" --send-preimage-hash true --send-proposal-as  democracy --register-index true --owner "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac" --index 0`
 
+### Example to note Pre-Image and propose through OpenGov2 with custom track
+
+`yarn set-transact-info -s v2 --track '{ "Origins": "YourCustomOrigin" }' --ws-provider ws://127.0.0.1:34102  --destination  '{ "parents": 1, "interior": "Here" }' --fee-per-second 8 --extra-weight 3000000000 --max-weight 20000000000 --account-priv-key "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133" --send-preimage-hash true`
+
+The `track` field must be a JSON formatted representation of the `referenda.submit` extrinsic's `proposalOrigin` input.  
+
 
 ## XCM-derivative-index-registrator script
 
@@ -165,6 +189,11 @@ The script accepts these inputs fields:
 
 `yarn register-derivative-index -w ws://127.0.0.1:34102  --index  0 --owner "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac" --account-priv-key "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133" --send-preimage-hash true --send-proposal-as council-external --collective-threshold 2`
 
+### Example to note Pre-Image and propose through OpenGov2 with custom track
+
+`yarn register-derivative-index -s v2 --track '{ "Origins": "YourCustomOrigin" }' -w ws://127.0.0.1:34102  --index  0 --owner "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac" --account-priv-key "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133" --send-preimage-hash true`
+
+The `track` field must be a JSON formatted representation of the `referenda.submit` extrinsic's `proposalOrigin` input.  
 
 ## Statemint-HRMP-relay-proposal-generator script
 
@@ -222,6 +251,12 @@ The script accepts these inputs fields:
 ### Example through council
 
 `yarn generic-call-propose -w ws://127.0.0.1:34102  --call "0x0302f24ff3a9cf04c71dbc94d0b566f7a27b94566cacc0f0f4ab324c46e55d02d0033343b4be8a55532d28" --account-priv-key "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133" --send-preimage-hash true --send-proposal-as council-external --collective-threshold 2`
+
+### Example to note Pre-Image and propose through OpenGov2 with custom track
+
+`yarn generic-call-propose -s v2 --track '{ "Origins": "YourCustomOrigin" }' -w ws://127.0.0.1:34102  --call "0x0302f24ff3a9cf04c71dbc94d0b566f7a27b94566cacc0f0f4ab324c46e55d02d0033343b4be8a55532d28" --account-priv-key "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133" --send-preimage-hash true`
+
+The `track` field must be a JSON formatted representation of the `referenda.submit` extrinsic's `proposalOrigin` input.  
 
 ### Example through democracy but batching 2 txs
 

--- a/scripts/generic-call-proposer.ts
+++ b/scripts/generic-call-proposer.ts
@@ -17,7 +17,7 @@ const args = yargs.options({
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
   "send-proposal-as": {
-    choices: ["democracy", "council-external"],
+    choices: ["democracy", "v1", "council-external", "v2"],
     demandOption: false,
     alias: "s",
   },

--- a/scripts/generic-call-proposer.ts
+++ b/scripts/generic-call-proposer.ts
@@ -33,8 +33,6 @@ async function main() {
 
   const collectiveThreshold = args["collective-threshold"] ?? 1;
 
-  const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
-
   let Tx;
   if (Array.isArray(args["generic-call"])) {
     let Txs = [];
@@ -86,7 +84,6 @@ async function main() {
       api,
       args["send-proposal-as"],
       preimage,
-      proposalAmount,
       account,
       nonce,
       collectiveThreshold

--- a/scripts/generic-call-proposer.ts
+++ b/scripts/generic-call-proposer.ts
@@ -23,6 +23,8 @@ const args = yargs.options({
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
+  "delay": { type: "string", demandOption: false },
+  "track": { type: "string", demandOption: false }
 }).argv;
 
 // Construct
@@ -86,7 +88,9 @@ async function main() {
       preimage,
       account,
       nonce,
-      collectiveThreshold
+      collectiveThreshold,
+      args["track"],
+      args["delay"]
     );
   }
 }

--- a/scripts/helpers/function-helpers.ts
+++ b/scripts/helpers/function-helpers.ts
@@ -117,18 +117,21 @@ export async function democracyWrapper(
       console.log("--> Democracy Tx sent\n");
     }
     else if (proposalType == "v2") {
-      const tracks = {
+      let t = {
         root: { system: 'Root' },
         whitelisted: { Origins: 'WhitelistedCaller' } ,
         general: { Origins: 'GeneralAdmin' },
         canceller: { Origins: 'ReferendumCanceller' },
         killer: { Origins: 'ReferendumKiller' }
-      };
-      if(tracks[track] == undefined) throw new Error(`${track} is not a valid track for OpenGovV2. Use root, whitelisted, general, canceller, or killer.`);
-      console.log(preimage);
+      }[track];
+      
+      if(t == undefined) {
+        t = JSON.parse(track);
+      }
+
       await api.tx.referenda
         .submit(
-          tracks[track],
+          t,
           { Lookup: { hash_: preimage["encodedHash"], len: preimage["encodedLength"] } },
           { After: delay ?? 100 } // Set to 100 blocks by default, like in Polkadot.js Apps
         )

--- a/scripts/helpers/function-helpers.ts
+++ b/scripts/helpers/function-helpers.ts
@@ -88,7 +88,6 @@ export async function democracyWrapper(
   api,
   proposalType,
   preimage,
-  proposalAmount,
   account,
   nonce,
   collectiveThreshold?,
@@ -100,6 +99,8 @@ export async function democracyWrapper(
 
     // OpenGovV1, OpenGovV2, or Council
     if ((proposalType == "democracy" && track == null) || proposalType == "democracy-v1" || proposalType == "v1") {
+      const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
+
       if (runtimeVersion < 2000n) {
         await api.tx.democracy
           .propose(preimage["encodedHash"], proposalAmount)

--- a/scripts/helpers/function-helpers.ts
+++ b/scripts/helpers/function-helpers.ts
@@ -98,7 +98,7 @@ export async function democracyWrapper(
     let runtimeVersion = BigInt(api.runtimeVersion.specVersion);
 
     // OpenGovV1, OpenGovV2, or Council
-    if ((proposalType == "democracy" && track == null) || proposalType == "democracy-v1" || proposalType == "v1") {
+    if (proposalType == "democracy" || proposalType == "v1") {
       const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
 
       if (runtimeVersion < 2000n) {
@@ -116,15 +116,16 @@ export async function democracyWrapper(
 
       console.log("--> Democracy Tx sent\n");
     }
-    else if ((proposalType == "democracy" && track != null) || proposalType == "democracy-v2" || proposalType == "v2") {
+    else if (proposalType == "v2") {
       const tracks = {
-        root: { origin: { system: 'Root' } },
-        whitelisted: { origin: { Origins: 'WhitelistedCaller' } } ,
-        general: { origin: { Origins: 'GeneralAdmin' } },
-        canceller: { origin: { Origins: 'ReferendumCanceller' } },
-        killer: { origin: { Origins: 'ReferendumKiller' } }
+        root: { system: 'Root' },
+        whitelisted: { Origins: 'WhitelistedCaller' } ,
+        general: { Origins: 'GeneralAdmin' },
+        canceller: { Origins: 'ReferendumCanceller' },
+        killer: { Origins: 'ReferendumKiller' }
       };
       if(tracks[track] == undefined) throw new Error(`${track} is not a valid track for OpenGovV2. Use root, whitelisted, general, canceller, or killer.`);
+      console.log(preimage);
       await api.tx.referenda
         .submit(
           tracks[track],

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -26,7 +26,7 @@ const args = yargs.options({
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
   "send-proposal-as": {
-    choices: ["democracy", "council-external"],
+    choices: ["democracy", "v1", "council-external", "v2"],
     demandOption: false,
     alias: "s",
   },

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -80,12 +80,10 @@ async function main() {
 
   // Send Democracy Proposal
   if (args["send-proposal-as"]) {
-    const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
     await democracyWrapper(
       api,
       args["send-proposal-as"],
       preimage,
-      proposalAmount,
       account,
       nonce,
       collectiveThreshold

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -33,6 +33,8 @@ const args = yargs.options({
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
   "fee-currency": { type: "string", demandOption: false },
+  "delay": { type: "string", demandOption: false },
+  "track": { type: "string", demandOption: false }
 }).argv;
 
 // Construct
@@ -86,7 +88,9 @@ async function main() {
       preimage,
       account,
       nonce,
-      collectiveThreshold
+      collectiveThreshold,
+      args["track"],
+      args["delay"]
     );
   }
 }

--- a/scripts/statemint-hrmp-relay-proposal-generator.ts
+++ b/scripts/statemint-hrmp-relay-proposal-generator.ts
@@ -46,8 +46,6 @@ async function main() {
 
   const collectiveThreshold = args["collective-threshold"] ?? 1;
 
-  const proposalAmount = (await relayApi.consts.democracy.minimumDeposit) as any;
-
   const statemintParaId: ParaId = (await statemintApi.query.parachainInfo.parachainId()) as any;
   const targetParaId: ParaId = relayApi.createType("ParaId", args["target-para-id"]);
 
@@ -165,7 +163,6 @@ async function main() {
       relayApi,
       args["send-proposal-as"],
       preimage,
-      proposalAmount,
       account,
       nonce,
       collectiveThreshold

--- a/scripts/statemint-hrmp-relay-proposal-generator.ts
+++ b/scripts/statemint-hrmp-relay-proposal-generator.ts
@@ -34,6 +34,8 @@ const args = yargs.options({
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
+  "delay": { type: "string", demandOption: false },
+  "track": { type: "string", demandOption: false }
 }).argv;
 
 // Construct
@@ -165,7 +167,9 @@ async function main() {
       preimage,
       account,
       nonce,
-      collectiveThreshold
+      collectiveThreshold,
+      args["track"],
+      args["delay"]
     );
   }
 }

--- a/scripts/statemint-hrmp-relay-proposal-generator.ts
+++ b/scripts/statemint-hrmp-relay-proposal-generator.ts
@@ -28,7 +28,7 @@ const args = yargs.options({
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: true, alias: "h" },
   "send-proposal-as": {
-    choices: ["democracy", "council-external"],
+    choices: ["democracy", "v1", "council-external", "v2"],
     demandOption: false,
     alias: "s",
   },

--- a/scripts/xcm-asset-registrator.ts
+++ b/scripts/xcm-asset-registrator.ts
@@ -26,14 +26,17 @@ const args = yargs.options({
   "revert-code": { type: "boolean", demandOption: false, alias: "revert" },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
   "send-proposal-as": {
-    choices: ["democracy", "council-external"],
+    choices: ["democracy", "v1", "council-external", "v2"],
     demandOption: false,
     alias: "s",
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
-  "track": { type: "string", demandOption: false },
-  "delay": { type: "string", demandOption: false }
+  "delay": { type: "string", demandOption: false },
+  "track": { 
+    choices: ["root", "whitelisted", "general", "canceller", "killer"], 
+    demandOption: false 
+  }
 }).argv;
 
 // Construct
@@ -139,7 +142,9 @@ async function main() {
       preimage,
       account,
       nonce,
-      collectiveThreshold
+      collectiveThreshold,
+      args["track"],
+      args["delay"]
     );
   }
 }

--- a/scripts/xcm-asset-registrator.ts
+++ b/scripts/xcm-asset-registrator.ts
@@ -32,6 +32,8 @@ const args = yargs.options({
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
+  "track": { type: "string", demandOption: false },
+  "delay": { type: "string", demandOption: false }
 }).argv;
 
 // Construct
@@ -41,8 +43,6 @@ async function main() {
   const api = await ApiPromise.create({ provider: wsProvider });
 
   const collectiveThreshold = args["collective-threshold"] ?? 1;
-
-  const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
 
   const assetMetadata = {
     name: args["name"],
@@ -137,7 +137,6 @@ async function main() {
       api,
       args["send-proposal-as"],
       preimage,
-      proposalAmount,
       account,
       nonce,
       collectiveThreshold

--- a/scripts/xcm-asset-registrator.ts
+++ b/scripts/xcm-asset-registrator.ts
@@ -33,10 +33,7 @@ const args = yargs.options({
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
   "delay": { type: "string", demandOption: false },
-  "track": { 
-    choices: ["root", "whitelisted", "general", "canceller", "killer"], 
-    demandOption: false 
-  }
+  "track": { type: "string", demandOption: false }
 }).argv;
 
 // Construct

--- a/scripts/xcm-derivative-index-registrar.ts
+++ b/scripts/xcm-derivative-index-registrar.ts
@@ -33,8 +33,6 @@ async function main() {
 
   const collectiveThreshold = args["collective-threshold"] ?? 1;
 
-  const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
-
   let registerTx = api.tx.xcmTransactor.register(args["owner"], args["index"]);
 
   // Scheduler
@@ -66,7 +64,6 @@ async function main() {
       api,
       args["send-proposal-as"],
       preimage,
-      proposalAmount,
       account,
       nonce,
       collectiveThreshold

--- a/scripts/xcm-derivative-index-registrar.ts
+++ b/scripts/xcm-derivative-index-registrar.ts
@@ -23,6 +23,8 @@ const args = yargs.options({
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
+  "delay": { type: "string", demandOption: false },
+  "track": { type: "string", demandOption: false }
 }).argv;
 
 // Construct
@@ -66,7 +68,9 @@ async function main() {
       preimage,
       account,
       nonce,
-      collectiveThreshold
+      collectiveThreshold,
+      args["track"],
+      args["delay"]
     );
   }
 }

--- a/scripts/xcm-derivative-index-registrar.ts
+++ b/scripts/xcm-derivative-index-registrar.ts
@@ -17,7 +17,7 @@ const args = yargs.options({
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
   "send-proposal-as": {
-    choices: ["democracy", "council-external"],
+    choices: ["democracy", "v1", "council-external", "v2"],
     demandOption: false,
     alias: "s",
   },

--- a/scripts/xcm-initializer.ts
+++ b/scripts/xcm-initializer.ts
@@ -36,8 +36,6 @@ async function main() {
 
   const collectiveThreshold = args["collective-threshold"] ?? 1;
 
-  const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
-
   const initializeTxs = [];
 
   if (args["default-xcm-version"]) {
@@ -159,7 +157,6 @@ async function main() {
       api,
       args["send-proposal-as"],
       preimage,
-      proposalAmount,
       account,
       nonce,
       collectiveThreshold

--- a/scripts/xcm-initializer.ts
+++ b/scripts/xcm-initializer.ts
@@ -26,6 +26,8 @@ const args = yargs.options({
     alias: "s",
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
+  "delay": { type: "string", demandOption: false },
+  "track": { type: "string", demandOption: false }
 }).argv;
 
 // Construct
@@ -159,7 +161,9 @@ async function main() {
       preimage,
       account,
       nonce,
-      collectiveThreshold
+      collectiveThreshold,
+      args["track"],
+      args["delay"]
     );
   }
 }

--- a/scripts/xcm-transactor-info-setter.ts
+++ b/scripts/xcm-transactor-info-setter.ts
@@ -38,8 +38,6 @@ async function main() {
 
   const collectiveThreshold = args["collective-threshold"] ?? 1;
 
-  const proposalAmount = (await api.consts.democracy.minimumDeposit) as any;
-
   const transactInfoSetTxs = [];
   const destination: MultiLocation = api.createType(
     "MultiLocation",
@@ -93,7 +91,6 @@ async function main() {
       api,
       args["send-proposal-as"],
       preimage,
-      proposalAmount,
       account,
       nonce,
       collectiveThreshold

--- a/scripts/xcm-transactor-info-setter.ts
+++ b/scripts/xcm-transactor-info-setter.ts
@@ -28,6 +28,8 @@ const args = yargs.options({
     alias: "s",
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
+  "delay": { type: "string", demandOption: false },
+  "track": { type: "string", demandOption: false }
 }).argv;
 
 // Construct
@@ -93,7 +95,9 @@ async function main() {
       preimage,
       account,
       nonce,
-      collectiveThreshold
+      collectiveThreshold,
+      args["track"],
+      args["delay"]
     );
   }
 }

--- a/scripts/xcm-transactor-info-setter.ts
+++ b/scripts/xcm-transactor-info-setter.ts
@@ -23,7 +23,7 @@ const args = yargs.options({
   sudo: { type: "boolean", demandOption: false, alias: "x", nargs: 0 },
   "send-preimage-hash": { type: "boolean", demandOption: false, alias: "h" },
   "send-proposal-as": {
-    choices: ["democracy", "council-external"],
+    choices: ["democracy", "v1", "council-external", "v2"],
     demandOption: false,
     alias: "s",
   },


### PR DESCRIPTION
Added "track" and "delay" flags to democracy scripts. Also added "v2" option for sendProposalAs, which will use referenda.submit instead of the democracy pallet.

"track" includes 5 scripted tracks but also allows for the JSON formatting of the origin object.

