### PR TITLE
Genesis hash for HRMP Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The script accepts these inputs fields:
 - `--send-proposal-as` or `-s`, optional, but if providede needs to be "democracy" or "council-external" specifying whether we want to send the proposal through regular democracy or as an external proposal that will be voted by the council
 - `--collective-threshold` or `-c`, Optional, number specifying the number of council votes that need to aprove the proposal. If not provided defautls to 1.
 - `--at-block`, Optional, number specifying the block number at which the call should get executed.
+- `--fee-currency`, Optional, the Multiasset to use to pay for the transaction in the XCM transaction
+- `--fee-amount`, Optional, the amount of fee to pay in the XCM transaction
 
 ### Example to note Pre-Image and propose
 

--- a/scripts/helpers/hrmp-helper.ts
+++ b/scripts/helpers/hrmp-helper.ts
@@ -15,7 +15,6 @@ export async function hrmpHelper(
   const selfParaId: ParaId = (await api.query.parachainInfo.parachainId()) as any;
 
   // Determine fee amount from relay chain
-  console.log("about to get genesis hash");
   const genesisHash = (await relayApi.genesisHash).toString().toLowerCase();
   console.log("Genesis hash is: " + genesisHash);
   const feeAmount: BN = fee ? new BN(fee) : (() => {

--- a/scripts/helpers/hrmp-helper.ts
+++ b/scripts/helpers/hrmp-helper.ts
@@ -15,31 +15,23 @@ export async function hrmpHelper(
   const relayChainInfo = (await relayApi.registry.getChainProperties()) as any;
 
   // Determine fee amount from relay chain
-  let feeAmount;
-  switch (relayChainInfo["tokenDecimals"].toHuman()?.[0]) {
-    case "12":
-      // Kusama - 0.1 KSM
-      feeAmount = new BN(100000000000);
-      break;
-    case "10":
-      // Polkadot - 1 DOT
-      feeAmount = new BN(10000000000);
-      break;
-    default:
-      const genesisHash = (await relayApi.genesisHash) as any;
-      if (
-        genesisHash.toString().toLowerCase() ===
-        "0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443"
-      ) {
+  const genesisHash = (await relayApi.genesisHash).toString().toLowerCase();
+  const feeAmount: BN = (() => {
+    switch (genesisHash) {
+      case "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe":
+        // Kusama - 0.1 KSM
+        return new BN(100000000000);
+      case "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3":
+        // Polkadot - 1 DOT
+        return new BN(10000000000);
+      case "0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443":
         // Moonbase Alpha Relay - 1 UNIT
-        feeAmount = new BN(1000000000000);
-        break;
-      } else {
+        return new BN(1000000000000);
+      default:
         // Generic Relay - 1 UNIT
-        feeAmount = new BN(1000000000000);
-        break;
-      }
-  }
+        return new BN(1000000000000);
+    }
+  })();
 
   // Attempt to find & use the xcmTransactor...
   try {

--- a/scripts/helpers/hrmp-helper.ts
+++ b/scripts/helpers/hrmp-helper.ts
@@ -15,26 +15,26 @@ export async function hrmpHelper(
   const selfParaId: ParaId = (await api.query.parachainInfo.parachainId()) as any;
 
   // Determine fee amount from relay chain
+  console.log("about to get genesis hash");
   const genesisHash = (await relayApi.genesisHash).toString().toLowerCase();
-  const feeAmount: BN = new BN(fee) ?? (() => {
+  console.log("Genesis hash is: " + genesisHash);
+  const feeAmount: BN = fee ? new BN(fee) : (() => {
     switch (genesisHash) {
       case "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe":
         // Kusama - 0.1 KSM
-        console.log("KUSAMA")
         return new BN(100000000000);
       case "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3":
         // Polkadot - 1 DOT
-        console.log("DOT")
         return new BN(10000000000);
       case "0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443":
         // Moonbase Alpha Relay - 1 UNIT
-        console.log("MOONBASE RELAY")
         return new BN(1000000000000);
       default:
         // Generic Relay - 1 UNIT
         return new BN(1000000000000);
     }
   })();
+  console.log("FeeAmount is: " + feeAmount)
 
   // Attempt to find & use the xcmTransactor...
   try {

--- a/scripts/helpers/hrmp-helper.ts
+++ b/scripts/helpers/hrmp-helper.ts
@@ -9,23 +9,26 @@ export async function hrmpHelper(
   targetParaId,
   maxCapacity = 1000,
   maxMessageSize = 102400,
-  feeCurrency = null
+  feeCurrency = null,
+  fee = null
 ) {
   const selfParaId: ParaId = (await api.query.parachainInfo.parachainId()) as any;
-  const relayChainInfo = (await relayApi.registry.getChainProperties()) as any;
 
   // Determine fee amount from relay chain
   const genesisHash = (await relayApi.genesisHash).toString().toLowerCase();
-  const feeAmount: BN = (() => {
+  const feeAmount: BN = new BN(fee) ?? (() => {
     switch (genesisHash) {
       case "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe":
         // Kusama - 0.1 KSM
+        console.log("KUSAMA")
         return new BN(100000000000);
       case "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3":
         // Polkadot - 1 DOT
+        console.log("DOT")
         return new BN(10000000000);
       case "0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443":
         // Moonbase Alpha Relay - 1 UNIT
+        console.log("MOONBASE RELAY")
         return new BN(1000000000000);
       default:
         // Generic Relay - 1 UNIT

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -33,7 +33,7 @@ const args = yargs.options({
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
   "fee-currency": { type: "string", demandOption: false },
-  "fee-amount": { type: "number", demandOption: false }
+  "fee-amount": { type: "string", demandOption: false }
 }).argv;
 
 // Construct

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -33,6 +33,7 @@ const args = yargs.options({
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
   "fee-currency": { type: "string", demandOption: false },
+  "fee-amount": { type: "number", demandOption: false }
 }).argv;
 
 // Construct
@@ -53,7 +54,8 @@ async function main() {
     args["target-para-id"],
     args["max-capacity"],
     args["max-message-size"],
-    args["fee-currency"]
+    args["fee-currency"],
+    args["fee-amount"]
   );
 
   // Scheduler


### PR DESCRIPTION
- Switched the HRMP helper's feeAmount selection to one that depends on the relay chain's genesisHash instead of the number of decimals
- Added a new parameter that allows users to define the feeAmount