### PR TITLE
XCM V3 General Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ The script accepts these inputs fields:
 - `--parachain-ws-provider` or `--w`, which specifies the parachain websocket provider to which we will be issuing our requests
 - `--relay-ws-provider` or `--wr`, which specifies the relay websocket provider to which we will be issuing our requests
 - `--hrmp-action` or `--hrmp`, one of "accept", "close", "cancel", or "open".
+- `--force-xcm-send` or `--xcm-send`, boolean to force `polkadotXcm.send` over `xcmTransactor`
 - `--target-para-id` or `-p`, The target paraId with which we interact.
-- `--max-capacity` or `--mc`, Optional, only for "open". The max capacity in messages that the channel supports.
-- `--max-message-size` or `-mms`, Optional, only for "open". The max message size that the channel supports.
+- `--max-capacity` or `--mc`, Optional, only for "open". The max capacity in messages that the channel supports
+- `--max-message-size` or `-mms`, Optional, only for "open". The max message size that the channel supports
 - `--account-priv-key` or `-a`, which specifies the account that will submit the proposal
 - `--sudo` or `-x`, which wraps the transaction with `sudo.sudo`. If the private key is included it will also send it, if not, it will only provide the encoded call data
 - `--send-preimage-hash` or `-h`, boolean specifying whether we want to send the preimage hash

--- a/scripts/generic-call-proposer.ts
+++ b/scripts/generic-call-proposer.ts
@@ -44,7 +44,7 @@ async function main() {
       let call = api.createType("Call", hexToU8a(args["generic-call"][i])) as any;
       Txs.push(call);
     }
-    const batchCall = api.tx.utility.batchAll(Txs);
+    const batchCall = api.tx.utility.batch(Txs);
     Tx = batchCall;
   } else {
     // Else, we just push one

--- a/scripts/generic-call-proposer.ts
+++ b/scripts/generic-call-proposer.ts
@@ -23,8 +23,8 @@ const args = yargs.options({
   },
   "collective-threshold": { type: "number", demandOption: false, alias: "c" },
   "at-block": { type: "number", demandOption: false },
-  "delay": { type: "string", demandOption: false },
-  "track": { type: "string", demandOption: false }
+  delay: { type: "string", demandOption: false },
+  track: { type: "string", demandOption: false },
 }).argv;
 
 // Construct
@@ -44,7 +44,7 @@ async function main() {
       let call = api.createType("Call", hexToU8a(args["generic-call"][i])) as any;
       Txs.push(call);
     }
-    const batchCall = api.tx.utility.batch(Txs);
+    const batchCall = api.tx.utility.batchAll(Txs);
     Tx = batchCall;
   } else {
     // Else, we just push one

--- a/scripts/helpers/get-xcm-version.ts
+++ b/scripts/helpers/get-xcm-version.ts
@@ -3,7 +3,7 @@ export async function getXCMVersion(provider: any): Promise<[string, string]> {
   let xcmpQueueVersion = (await provider.query.xcmpQueue.palletVersion()) as any;
   let xcmSafeVersion = (await provider.query.polkadotXcm.safeXcmVersion()) as any;
   let xcmVersion = `V${Math.max(xcmpQueueVersion, xcmSafeVersion).toString()}`;
-  console.log(`\nXCM Version is ${xcmVersion}`);
+  console.log(`XCM Version is ${xcmVersion}`);
 
   // Get XCM Versioned Multilocation Type
   const xcmType = xcmVersion === "V3" ? "XcmV3MultiLocation" : "XcmV1MultiLocation";

--- a/scripts/helpers/hrmp-helper.ts
+++ b/scripts/helpers/hrmp-helper.ts
@@ -11,13 +11,14 @@ export async function hrmpHelper(
   maxCapacity = 1000,
   maxMessageSize = 102400,
   feeCurrency = null,
-  fee = null
+  fee = null,
+  forceXcmSend = null
 ) {
   const selfParaId: ParaId = (await api.query.parachainInfo.parachainId()) as any;
 
   // Determine fee amount from relay chain
   const genesisHash = (await relayApi.genesisHash).toString().toLowerCase();
-  console.log("Genesis hash is: " + genesisHash);
+  console.log("\nGenesis hash is: " + genesisHash);
   const feeAmount: BN = fee
     ? new BN(fee)
     : (() => {
@@ -41,8 +42,10 @@ export async function hrmpHelper(
   // Get XCM Version and MultiLocation Type
   const [xcmVersion, xcmType] = await getXCMVersion(api);
 
-  // Attempt to find & use the xcmTransactor...
-  try {
+  // Check if Force XCM Send or Not, and Check XCM Transactor
+  const useTransactor = forceXcmSend ? false : api.query.xcmTransactor ? true : false;
+
+  if (useTransactor) {
     // Find correct HRMP action
     let action;
     if (hrmpAction == "accept") {
@@ -121,11 +124,11 @@ export async function hrmpHelper(
           }
     );
     return xcmTransactorHrmpManageExtrinsic;
-  } catch (_) {
+  } else {
     // ...otherwise, use the legacy construction method
     let relayCall;
     if (hrmpAction == "accept") {
-      relayCall = relayApi.tx.hrmp.hrmpAcceptOpenChannel(maxCapacity);
+      relayCall = relayApi.tx.hrmp.hrmpAcceptOpenChannel(targetParaId);
     } else if (hrmpAction == "open") {
       relayCall = relayApi.tx.hrmp.hrmpInitOpenChannel(targetParaId, maxCapacity, maxMessageSize);
     } else if (hrmpAction == "cancel") {
@@ -146,58 +149,70 @@ export async function hrmpHelper(
       new Uint8Array([...new TextEncoder().encode("para"), ...selfParaId.toU8a()])
     ).padEnd(66, "0");
 
+    const xcmMessage: any = [
+      {
+        WithdrawAsset: [
+          {
+            id: { Concrete: { parents: new BN(0), interior: "Here" } },
+            fun: { Fungible: feeAmount },
+          },
+        ],
+      },
+      {
+        BuyExecution: {
+          fees: {
+            id: { Concrete: { parents: new BN(0), interior: "Here" } },
+            fun: { Fungible: feeAmount },
+          },
+          weightLimit: "Unlimited",
+        },
+      },
+      {
+        Transact: {
+          originType: "Native",
+          requireWeightAtMost:
+            xcmVersion == "V3"
+              ? {
+                  refTime: new BN(1000000000),
+                  proofSize: new BN(65536),
+                }
+              : new BN(1000000000),
+          call: {
+            encoded: relayCall2,
+          },
+        },
+      },
+    ];
+
+    // DepositAsset depends on XCM V3 or V2
+    xcmVersion == "V3"
+      ? xcmMessage.push({
+          DepositAsset: {
+            assets: { Wild: { AllCounted: 1 } },
+            beneficiary: {
+              parents: new BN(0),
+              interior: { X1: { AccountId32: { network: null, id: para_address } } },
+            },
+          },
+        })
+      : xcmMessage.push({
+          DepositAsset: {
+            assets: { Wild: "All" },
+            max_assets: 1,
+            beneficiary: {
+              parents: new BN(0),
+              interior: { X1: { AccountId32: { network: "Any", id: para_address } } },
+            },
+          },
+        });
+
+    // XCM Send
     const batchCall = api.tx.polkadotXcm.send(
       xcmVersion == "V3"
         ? { V3: { parents: new BN(1), interior: "Here" } }
         : { V1: { parents: new BN(1), interior: "Here" } },
       {
-        [xcmVersion]: [
-          {
-            WithdrawAsset: [
-              {
-                id: { Concrete: { parents: new BN(0), interior: "Here" } },
-                fun: { Fungible: feeAmount },
-              },
-            ],
-          },
-          {
-            BuyExecution: {
-              fees: {
-                id: { Concrete: { parents: new BN(0), interior: "Here" } },
-                fun: { Fungible: feeAmount },
-              },
-              weightLimit: "Unlimited",
-            },
-          },
-          {
-            Transact: {
-              originType: "Native",
-              requireWeightAtMost:
-                xcmVersion == "V3"
-                  ? {
-                      refTime: new BN(1000000000),
-                      proofSize: new BN(65536),
-                    }
-                  : new BN(1000000000),
-              call: {
-                encoded: relayCall2,
-              },
-            },
-          },
-          {
-            DepositAsset: {
-              assets: { Wild: "All" },
-              max_assets: 1,
-              beneficiary: {
-                parents: new BN(0),
-                interior:
-                  xcmVersion == "V3"
-                    ? { X1: { AccountId32: { network: null, id: para_address } } }
-                    : { X1: { AccountId32: { network: "Any", id: para_address } } },
-              },
-            },
-          },
-        ],
+        [xcmVersion]: xcmMessage,
       }
     );
 

--- a/scripts/helpers/hrmp-helper.ts
+++ b/scripts/helpers/hrmp-helper.ts
@@ -22,30 +22,31 @@ export async function hrmpHelper(
   const feeAmount: BN = fee
     ? new BN(fee)
     : (() => {
-        switch (genesisHash) {
-          case "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe":
-            // Kusama - 0.1 KSM
-            return new BN(100000000000);
-          case "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3":
-            // Polkadot - 1 DOT
-            return new BN(10000000000);
-          case "0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443":
-            // Moonbase Alpha Relay - 1 UNIT
-            return new BN(1000000000000);
-          default:
-            // Generic Relay - 1 UNIT
-            return new BN(1000000000000);
-        }
-      })();
+      switch (genesisHash) {
+        case "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe":
+          // Kusama - 0.1 KSM
+          return new BN(100000000000);
+        case "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3":
+          // Polkadot - 1 DOT
+          return new BN(10000000000);
+        case "0xe1ea3ab1d46ba8f4898b6b4b9c54ffc05282d299f89e84bd0fd08067758c9443":
+          // Moonbase Alpha Relay - 1 UNIT
+          return new BN(1000000000000);
+        default:
+          // Generic Relay - 1 UNIT
+          return new BN(1000000000000);
+      }
+    })();
   console.log("FeeAmount is: " + feeAmount);
 
   // Get XCM Version and MultiLocation Type
   const [xcmVersion, xcmType] = await getXCMVersion(api);
 
-  // Check if Force XCM Send or Not, and Check XCM Transactor
-  const useTransactor = forceXcmSend ? false : api.query.xcmTransactor ? true : false;
+  try {
+    // Check if Force XCM Send or Not, and Check XCM Transactor
+    const useTransactor = forceXcmSend ? false : api.query.xcmTransactor ? true : false;
+    if(!useTransactor) throw new Error("XCM construction method was forced by user.");
 
-  if (useTransactor) {
     // Find correct HRMP action
     let action;
     if (hrmpAction == "accept") {
@@ -91,17 +92,17 @@ export async function hrmpHelper(
         AsMultiLocation:
           xcmVersion == "V3"
             ? {
-                V3: {
-                  parents: asset.parents,
-                  interior: asset.interior,
-                },
-              }
-            : {
-                V1: {
-                  parents: asset.parents,
-                  interior: asset.interior,
-                },
+              V3: {
+                parents: asset.parents,
+                interior: asset.interior,
               },
+            }
+            : {
+              V1: {
+                parents: asset.parents,
+                interior: asset.interior,
+              },
+            },
       };
     }
 
@@ -115,16 +116,19 @@ export async function hrmpHelper(
       // Account for XCM V3, note the Proof Sizes are hardcoded for now
       xcmVersion == "V3"
         ? {
-            transactRequiredWeightAtMost: { refTime: new BN(1000000000), proofSize: new BN(65536) },
-            overallWeight: { refTime: new BN(5000000000), proofSize: new BN(131072) },
-          }
+          transactRequiredWeightAtMost: { refTime: new BN(1000000000), proofSize: new BN(65536) },
+          overallWeight: { refTime: new BN(5000000000), proofSize: new BN(131072) },
+        }
         : {
-            transactRequiredWeightAtMost: new BN(1000000000),
-            overallWeight: new BN(5000000000),
-          }
+          transactRequiredWeightAtMost: new BN(1000000000),
+          overallWeight: new BN(5000000000),
+        }
     );
     return xcmTransactorHrmpManageExtrinsic;
-  } else {
+  }
+  catch (e) {
+    console.log(`Not using XCM Transactor: ${e.message ?? '[no message specified]'}`);
+
     // ...otherwise, use the legacy construction method
     let relayCall;
     if (hrmpAction == "accept") {
@@ -173,9 +177,9 @@ export async function hrmpHelper(
           requireWeightAtMost:
             xcmVersion == "V3"
               ? {
-                  refTime: new BN(1000000000),
-                  proofSize: new BN(65536),
-                }
+                refTime: new BN(1000000000),
+                proofSize: new BN(65536),
+              }
               : new BN(1000000000),
           call: {
             encoded: relayCall2,
@@ -187,24 +191,24 @@ export async function hrmpHelper(
     // DepositAsset depends on XCM V3 or V2
     xcmVersion == "V3"
       ? xcmMessage.push({
-          DepositAsset: {
-            assets: { Wild: { AllCounted: 1 } },
-            beneficiary: {
-              parents: new BN(0),
-              interior: { X1: { AccountId32: { network: null, id: para_address } } },
-            },
+        DepositAsset: {
+          assets: { Wild: { AllCounted: 1 } },
+          beneficiary: {
+            parents: new BN(0),
+            interior: { X1: { AccountId32: { network: null, id: para_address } } },
           },
-        })
+        },
+      })
       : xcmMessage.push({
-          DepositAsset: {
-            assets: { Wild: "All" },
-            max_assets: 1,
-            beneficiary: {
-              parents: new BN(0),
-              interior: { X1: { AccountId32: { network: "Any", id: para_address } } },
-            },
+        DepositAsset: {
+          assets: { Wild: "All" },
+          max_assets: 1,
+          beneficiary: {
+            parents: new BN(0),
+            interior: { X1: { AccountId32: { network: "Any", id: para_address } } },
           },
-        });
+        },
+      });
 
     // XCM Send
     const batchCall = api.tx.polkadotXcm.send(

--- a/scripts/hrmp-channel-manipulator.ts
+++ b/scripts/hrmp-channel-manipulator.ts
@@ -19,6 +19,11 @@ const args = yargs.options({
     demandOption: true,
     alias: "hrmp",
   },
+  "force-xcm-send": {
+    type: "boolean",
+    demandOption: false,
+    alias: "xcm-send",
+  },
   "target-para-id": { type: "number", demandOption: true, alias: "p" },
   "max-capacity": { type: "number", demandOption: false, alias: "mc" },
   "max-message-size": { type: "number", demandOption: false, alias: "mms" },
@@ -57,7 +62,8 @@ async function main() {
     args["max-capacity"],
     args["max-message-size"],
     args["fee-currency"],
-    args["fee-amount"]
+    args["fee-amount"],
+    args["force-xcm-send"]
   );
 
   // Scheduler


### PR DESCRIPTION
The repo had an issue for chains in which there is XCM V3 to XCM V2 message conversion. This fixes that and adds an optional flag that is to force `polkadotXcm.send` to be used instead of `xcmTransactor`.